### PR TITLE
Fix crash for special case when parsing BCD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 target
 *.class
 
+# IntelliJ file-based
+*.iml
+*.ipr
+*.iws
+
 # Package Files #
 *.jar
 *.war

--- a/src/main/java/nl/cad/tpsparse/bin/RandomAccess.java
+++ b/src/main/java/nl/cad/tpsparse/bin/RandomAccess.java
@@ -486,7 +486,9 @@ public class RandomAccess {
                 break;
             }
         }
-        if (idx == number.length() - 1) {
+        if (number.length() == 0) {
+            return "0";
+        } else if (idx == number.length() - 1) {
             return number.substring(idx);
         } else {
             return number.substring(idx + 1);

--- a/src/test/java/nl/cad/tpsparse/bin/RandomAccessTest.java
+++ b/src/test/java/nl/cad/tpsparse/bin/RandomAccessTest.java
@@ -105,6 +105,10 @@ public class RandomAccessTest {
         // from real world TPS, 7 bytes -> 14 digits, minus one for the sign =
         // 13 digits, minus 8 behind the dot, remains 5 before, not 7!
         assertEquals("0.00000000", new RandomAccess(new byte[] { (byte) 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).binaryCodedDecimal(7, 7, 8));
+        // from real world TPS
+        // this number has 5 digits, with all of them coming after the decimal point
+        // this decimal is reported as DECIMAL(5,5) in the TopScan utility
+        assertEquals("0.50000", new RandomAccess(new byte[] { 0x05, 0x00, 0x00 }).binaryCodedDecimal(3, 3, 5));
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue where, when parsing a BCD where all digits come after the decimal place, `trimLeadingZeros()` would attempt to substring the zero-length right-side digit string. (i.e. "" would be substring'd by -1)