### PR TITLE
dereference index field name

### DIFF
--- a/src/main/java/nl/cad/tpsparse/tps/record/IndexDefinitionRecord.java
+++ b/src/main/java/nl/cad/tpsparse/tps/record/IndexDefinitionRecord.java
@@ -59,7 +59,7 @@ public class IndexDefinitionRecord {
     public List<FieldDefinitionRecord> getFieldRecords(TableDefinitionRecord rec) {
         List<FieldDefinitionRecord> results = new ArrayList<FieldDefinitionRecord>();
         for (int t = 0; t < keyField.length; t++) {
-            results.add(rec.getFields().get(t));
+            results.add(rec.getFields().get(keyField[t]));
         }
         return results;
     }


### PR DESCRIPTION
current name lookup uses the index into the keyField array not the id contained in the array to lookup the field name when outputting the index fields.